### PR TITLE
Link to correct help page on start date page

### DIFF
--- a/app/views/calculator/day_count_form.html.erb
+++ b/app/views/calculator/day_count_form.html.erb
@@ -1,5 +1,9 @@
 <%= render :partial => 'nav' %>
-<%= content_tag( 'p', link_to( 'Using the calculator', meta_using_url ) ) %>
+<% if @direction == 'reverse' %>
+    <%= content_tag( 'p', link_to( 'Using the calculator', meta_using_reverse_url ) ) %>
+<% else -%>
+    <%= content_tag( 'p', link_to( 'Using the calculator', meta_using_url ) ) %>
+<% end -%>
 
 <form action="" method="GET" id="calculator">
 	


### PR DESCRIPTION
This matches the links being displayed further down the same page.